### PR TITLE
Feature/generate open api specification

### DIFF
--- a/.graalvm/reflect-config.json
+++ b/.graalvm/reflect-config.json
@@ -312,11 +312,22 @@
     ]
   },
   {
-    "name" : "java.lang.Class",
-    "methods" : [
-      { "name" : "getSimpleName", "parameterTypes" : [] },
-      { "name" : "getInterfaces", "parameterTypes" : [] },
-      { "name" : "getInterfaces", "parameterTypes" : ["java.lang.boolean"] }
+    "name": "java.lang.Class",
+    "methods": [
+      {
+        "name": "getSimpleName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getInterfaces",
+        "parameterTypes": []
+      },
+      {
+        "name": "getInterfaces",
+        "parameterTypes": [
+          "java.lang.boolean"
+        ]
+      }
     ]
   },
   {

--- a/.graalvm/resource-config.json
+++ b/.graalvm/resource-config.json
@@ -71,6 +71,24 @@
     },
     {
       "pattern": "\\Qorg/apache/batik/transcoder/Transcoder.class\\E"
+    },
+    {
+      "pattern": "\\Qopenapi/OpenApiRootJson.json\\E"
+    },
+    {
+      "pattern": "\\Qopenapi/CursorBasedPaging.json\\E"
+    },
+    {
+      "pattern": "\\Qopenapi/Filter.json\\E"
+    },
+    {
+      "pattern": "\\Qopenapi/JsonRPC.json\\E"
+    },
+    {
+      "pattern": "\\Qopenapi/OffsetBasedPaging.json\\E"
+    },
+    {
+      "pattern": "\\Qopenapi/TimeBasedPaging.json\\E"
     }
   ]
 }

--- a/postman/ame.postman_collection.json
+++ b/postman/ame.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "60fc3835-36b0-43ff-a9b4-084c8616844b",
+		"_postman_id": "d11906f6-ce45-4709-94ff-d7bbab64eef5",
 		"name": "AME.POSTMAN.RESOURCES",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -25,7 +25,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:name \"AspectDefault\" ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:name \"property1\";\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:name \"Characteristic1\" ;\r\n    bamm:dataType xsd:string .\r\n"
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:dataType xsd:string .\r\n"
 				},
 				"url": {
 					"raw": "http://localhost:{{port}}/ame/api/models",
@@ -70,7 +70,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:name \"AspectDefault\" ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:name \"property1\";\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:name \"Characteristic1\" ;\r\n    bamm:dataType xsd:string .\r\n"
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:dataType xsd:string .\r\n"
 				},
 				"url": {
 					"raw": "http://localhost:{{port}}/ame/api/models",
@@ -273,7 +273,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:name \"AspectDefault\" ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:name \"property1\";\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:name \"Characteristic1\" ;\r\n    bamm:dataType xsd:string .\r\n"
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:dataType xsd:string .\r\n"
 				},
 				"url": {
 					"raw": "http://localhost:{{port}}/ame/api/models/validate",
@@ -314,7 +314,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:DefaultAspect a bamm:Aspect ;\r\n   bamm:name \"DefaultAspect\" ;\r\n   bamm:preferredName \"DefaultAspect\"@en ;\r\n   bamm:description \"DefaultAspect Description\"@en ;\r\n   bamm:properties ( :property1 ) ;\r\n   bamm:operations ( ) .\r\n\r\n:property1 a bamm:Property ;\r\n   bamm:name \"property1\" ;\r\n   bamm:preferredName \"Property 1 \"@en ;\r\n   bamm:description \"Property Description 1 \"@en ;\r\n   bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n   bamm:name \"Characteristic1\" ;\r\n   bamm:preferredName \"Characteristic 1 \"@en ;\r\n   bamm:description \"Characteristic Description 1 \"@en ;\r\n   bamm:dataType xsd:string .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n   bamm:name \"Characteristic2\" ;\r\n   bamm:preferredName \"Characteristic 2 \"@en ;\r\n   bamm:description \"Characteristic Description 2 \"@en ;\r\n   bamm:dataType xsd:string ."
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:DefaultAspect a bamm:Aspect ;\r\n   bamm:preferredName \"DefaultAspect\"@en ;\r\n   bamm:description \"DefaultAspect Description\"@en ;\r\n   bamm:properties ( :property1 ) ;\r\n   bamm:operations ( ) .\r\n\r\n:property1 a bamm:Property ;\r\n   bamm:preferredName \"Property 1 \"@en ;\r\n   bamm:description \"Property Description 1 \"@en ;\r\n   bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n   bamm:preferredName \"Characteristic 1 \"@en ;\r\n   bamm:description \"Characteristic Description 1 \"@en ;\r\n   bamm:dataType xsd:string .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n   bamm:preferredName \"Characteristic 2 \"@en ;\r\n   bamm:description \"Characteristic Description 2 \"@en ;\r\n   bamm:dataType xsd:string ."
 				},
 				"url": {
 					"raw": "http://localhost:{{port}}/ame/api/models/validate",
@@ -355,7 +355,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:name \"AspectDefaultUpdate\" ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:name \"property1Update\";\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:name \"Characteristic1Update\" \r\n    bamm:dataType xsd:string .\r\n"
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:characteristic :Characteristic1\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:dataType xsd:string .\r\n"
 				},
 				"url": {
 					"raw": "http://localhost:{{port}}/ame/api/models/validate",
@@ -437,7 +437,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectWithUsedAndUnusedConstraint a bamm:Aspect ;\r\n   bamm:name \"AspectWithUsedAndUnusedConstraint\" ;\r\n   bamm:properties ( :testProperty ) ;\r\n   bamm:operations ( ) .\r\n\r\n:testProperty a bamm:Property ;\r\n   bamm:name \"testProperty\" ;\r\n   bamm:characteristic :UsedTestTrait .\r\n\r\n:UsedTestTrait a bamm-c:Trait ;\r\n   bamm:name \"UsedTestTrait\" ;\r\n   bamm-c:constraint :UnusedTestConstraint ;\r\n   bamm-c:baseCharacteristic bamm-c:Text .\r\n\r\n:UnusedTestConstraint a bamm-c:LengthConstraint ;\r\n   bamm:name \"UnusedTestConstraint\" ;\r\n   bamm:preferredName \"Unused Test Constraint\"@en ;\r\n   bamm:description \"Unused Test Constraint\"@en ;\r\n   bamm:see <http://openmanufacturing.com> ;\r\n   bamm:see <http://openmanufacturing.com/me> ;\r\n   bamm-c:minValue \"5\"^^xsd:nonNegativeInteger ;\r\n   bamm-c:maxValue \"10\"^^xsd:nonNegativeInteger ."
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectWithUsedAndUnusedConstraint a bamm:Aspect ;\r\n   bamm:properties ( :testProperty ) ;\r\n   bamm:operations ( ) .\r\n\r\n:testProperty a bamm:Property ;\r\n   bamm:characteristic :UsedTestTrait .\r\n\r\n:UsedTestTrait a bamm-c:Trait ;\r\n   bamm-c:constraint :UnusedTestConstraint ;\r\n   bamm-c:baseCharacteristic bamm-c:Text .\r\n\r\n:UnusedTestConstraint a bamm-c:LengthConstraint ;\r\n   bamm:preferredName \"Unused Test Constraint\"@en ;\r\n   bamm:description \"Unused Test Constraint\"@en ;\r\n   bamm:see <http://openmanufacturing.com> ;\r\n   bamm:see <http://openmanufacturing.com/me> ;\r\n   bamm-c:minValue \"5\"^^xsd:nonNegativeInteger ;\r\n   bamm-c:maxValue \"10\"^^xsd:nonNegativeInteger ."
 				},
 				"url": {
 					"raw": "http://localhost:{{port}}/ame/api/models/validate",
@@ -479,7 +479,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:name \"AspectDefault\" ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:name \"property1\";\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:name \"Characteristic1\" ;\r\n    bamm:dataType xsd:string .\r\n"
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:dataType xsd:string .\r\n"
 				},
 				"url": {
 					"raw": "http://localhost:{{port}}/ame/api/generate/json-sample",
@@ -522,7 +522,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:name \"AspectDefault\" ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:name \"property1\";\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:name \"Characteristic1\" ;\r\n    bamm:dataType xsd:string .\r\n"
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:dataType xsd:string .\r\n"
 				},
 				"url": {
 					"raw": "http://localhost:{{port}}/ame/api/generate/json-schema",
@@ -561,7 +561,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\n\n:AspectDefault a bamm:Aspect ;\n    bamm:name \"AspectDefault\" ;\n    bamm:properties (:property1) ;\n    bamm:operations () .\n\n:property1 a bamm:Property;\n    bamm:name \"property1\";\n    bamm:characteristic :Characteristic1 .\n\n:Characteristic1 a bamm:Characteristic ;\n    bamm:name \"Characteristic1\" ."
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\n\n:AspectDefault a bamm:Aspect ;\n    bamm:properties (:property1) ;\n    bamm:operations () .\n\n:property1 a bamm:Property;\n    bamm:characteristic :Characteristic1 .\n\n:Characteristic1 a bamm:Characteristic ."
 				},
 				"url": {
 					"raw": "http://localhost:{{port}}/ame/api/generate/json-schema",
@@ -600,7 +600,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\n\n:AspectDefault a bamm:Aspect ;\n    bamm:name \"AspectDefault\" ;\n    bamm:properties (:property1) ;\n    bamm:operations () .\n\n:property1 a bamm:Property;\n    bamm:name \"property1\";\n    bamm:characteristic :Characteristic1 .\n\n:Characteristic1 a bamm:Characteristic ;\n    bamm:name \"Characteristic1\" ."
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\n\n:AspectDefault a bamm:Aspect ;\n    bamm:properties (:property1) ;\n    bamm:operations () .\n\n:property1 a bamm:Property;\n    bamm:characteristic :Characteristic1 .\n\n:Characteristic1 a bamm:Characteristic ."
 				},
 				"url": {
 					"raw": "http://localhost:{{port}}/ame/api/generate/json-sample",
@@ -614,6 +614,266 @@
 						"api",
 						"generate",
 						"json-sample"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GenerateJsonOpenApiSpec",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"pm.test(\"Response body is valid\", function () {\r",
+							"    const jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData.openapi).to.equal(\"3.0.3\");\r",
+							"    pm.expect(jsonData.info.title).to.equal(\"AspectDefault\");\r",
+							"    pm.expect(jsonData.info.version).to.equal(\"v1.0.0\");\r",
+							"    pm.expect(jsonData.servers[0].url).to.equal(\"http://www.test.com/api/v1.0.0\");\r",
+							"\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:dataType xsd:string .\r\n"
+				},
+				"url": {
+					"raw": "http://localhost:{{port}}/ame/api/generate/open-api-spec?output=json&baseUrl=http://www.test.com&includeQueryApi=true&useSemanticVersion=true&pagingOption=NO_PAGING",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "{{port}}",
+					"path": [
+						"ame",
+						"api",
+						"generate",
+						"open-api-spec"
+					],
+					"query": [
+						{
+							"key": "output",
+							"value": "json"
+						},
+						{
+							"key": "baseUrl",
+							"value": "http://www.test.com"
+						},
+						{
+							"key": "includeQueryApi",
+							"value": "true"
+						},
+						{
+							"key": "useSemanticVersion",
+							"value": "true"
+						},
+						{
+							"key": "pagingOption",
+							"value": "NO_PAGING"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GenerateYamlOpenApiSpec",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"pm.test(\"Response body is valid\", function () {\r",
+							"    const jsonData = pm.response.text();\r",
+							"    pm.expect(jsonData).to.include(\"openapi: 3.0.3\");\r",
+							"    pm.expect(jsonData).to.include(\"title: AspectDefault\");\r",
+							"    pm.expect(jsonData).to.include(\"version: v1\");\r",
+							"    pm.expect(jsonData).to.include(\"url: http://www.test.com/api/v1\");\r",
+							"\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic ;\r\n    bamm:dataType xsd:string .\r\n"
+				},
+				"url": {
+					"raw": "http://localhost:{{port}}/ame/api/generate/open-api-spec?output=yaml&baseUrl=http://www.test.com&includeQueryApi=false&useSemanticVersion=false&pagingOption=OFFSET_BASED_PAGING",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "{{port}}",
+					"path": [
+						"ame",
+						"api",
+						"generate",
+						"open-api-spec"
+					],
+					"query": [
+						{
+							"key": "output",
+							"value": "yaml"
+						},
+						{
+							"key": "baseUrl",
+							"value": "http://www.test.com"
+						},
+						{
+							"key": "includeQueryApi",
+							"value": "false"
+						},
+						{
+							"key": "useSemanticVersion",
+							"value": "false"
+						},
+						{
+							"key": "pagingOption",
+							"value": "OFFSET_BASED_PAGING"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GenerateJsonOpenApiSpecFromInvalidAspectModel",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(422);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic .\r\n"
+				},
+				"url": {
+					"raw": "http://localhost:{{port}}/ame/api/generate/open-api-spec?output=json&baseUrl=http://www.test.com&includeQueryApi=true&useSemanticVersion=true&pagingOption=NO_PAGING",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "{{port}}",
+					"path": [
+						"ame",
+						"api",
+						"generate",
+						"open-api-spec"
+					],
+					"query": [
+						{
+							"key": "output",
+							"value": "json"
+						},
+						{
+							"key": "baseUrl",
+							"value": "http://www.test.com"
+						},
+						{
+							"key": "includeQueryApi",
+							"value": "true"
+						},
+						{
+							"key": "useSemanticVersion",
+							"value": "true"
+						},
+						{
+							"key": "pagingOption",
+							"value": "NO_PAGING"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GenerateYamlOpenApiSpecFromInvalidAspectModel",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(422);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .\r\n@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .\r\n@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .\r\n@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .\r\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n@prefix : <urn:bamm:io.aspectmodel:1.0.0#> .\r\n\r\n:AspectDefault a bamm:Aspect ;\r\n    bamm:properties (:property1) ;\r\n    bamm:operations () .\r\n\r\n:property1 a bamm:Property;\r\n    bamm:characteristic :Characteristic1 .\r\n\r\n:Characteristic1 a bamm:Characteristic .\r\n"
+				},
+				"url": {
+					"raw": "http://localhost:{{port}}/ame/api/generate/open-api-spec?output=yaml&baseUrl=http://www.test.com&includeQueryApi=true&useSemanticVersion=true&pagingOption=NO_PAGING",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "{{port}}",
+					"path": [
+						"ame",
+						"api",
+						"generate",
+						"open-api-spec"
+					],
+					"query": [
+						{
+							"key": "output",
+							"value": "yaml"
+						},
+						{
+							"key": "baseUrl",
+							"value": "http://www.test.com"
+						},
+						{
+							"key": "includeQueryApi",
+							"value": "true"
+						},
+						{
+							"key": "useSemanticVersion",
+							"value": "true"
+						},
+						{
+							"key": "pagingOption",
+							"value": "NO_PAGING"
+						}
 					]
 				}
 			},

--- a/src/main/java/io/openmanufacturing/ame/exceptions/ResponseExceptionHandler.java
+++ b/src/main/java/io/openmanufacturing/ame/exceptions/ResponseExceptionHandler.java
@@ -30,6 +30,7 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import io.openmanufacturing.ame.exceptions.model.ErrorResponse;
+import io.openmanufacturing.sds.metamodel.loader.AspectLoadingException;
 
 /**
  * Provides custom exception handling for the REST API.
@@ -104,21 +105,34 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
    }
 
    /**
+    * Method for handling exception of type {@link AspectLoadingException}
+    *
+    * @param request the Http request
+    * @param e the exception which occurred
+    * @return the custom {@link ErrorResponse} as {@link ResponseEntity} for the exception
+    */
+   @ExceptionHandler( AspectLoadingException.class )
+   public ResponseEntity<Object> handleAspectLoadingException( final WebRequest request,
+         final AspectLoadingException e ) {
+      return error( HttpStatus.UNPROCESSABLE_ENTITY, request, e, e.getMessage() );
+   }
+
+   /**
     * Method for handling exception of type {@link InvalidAspectModelException}
     *
     * @param request the Http request
-    * @param e       the exception which occurred
+    * @param e the exception which occurred
     * @return the custom {@link ErrorResponse} as {@link ResponseEntity} for the exception
     */
-   @ExceptionHandler(InvalidAspectModelException.class)
-   public ResponseEntity<Object> handleInvalidAspectModelException(final WebRequest request,
-         final InvalidAspectModelException e) {
-      return error(HttpStatus.BAD_REQUEST, request, e, e.getMessage());
+   @ExceptionHandler( InvalidAspectModelException.class )
+   public ResponseEntity<Object> handleInvalidAspectModelException( final WebRequest request,
+         final InvalidAspectModelException e ) {
+      return error( HttpStatus.BAD_REQUEST, request, e, e.getMessage() );
    }
 
    private ResponseEntity<Object> error( final HttpStatus responseCode, final WebRequest request,
          final RuntimeException e, final String message ) {
-      logRequest(request, e, responseCode);
+      logRequest( request, e, responseCode );
 
       final ErrorResponse errorResponse = new ErrorResponse( message,
             ((ServletWebRequest) request).getRequest().getRequestURI(), responseCode.value() );
@@ -138,7 +152,8 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
       }
    }
 
-   private static String getLogRequestMessage( final WebRequest request, final Throwable ex, final HttpStatus httpStatus ) {
+   private static String getLogRequestMessage( final WebRequest request, final Throwable ex,
+         final HttpStatus httpStatus ) {
       final HttpServletRequest servletRequest = ((ServletWebRequest) request).getRequest();
       return servletRequest.getQueryString() == null ?
             getLogRequestMessage( servletRequest.getRequestURI(), ex, httpStatus ) :

--- a/src/main/java/io/openmanufacturing/ame/services/GenerateService.java
+++ b/src/main/java/io/openmanufacturing/ame/services/GenerateService.java
@@ -116,8 +116,8 @@ public class GenerateService {
          return generator.applyForYaml( ModelUtils.resolveAspectFromModel( aspectModel ), useSemanticVersion, baseUrl,
                Optional.empty(), Optional.empty(), includeQueryApi, pagingOption );
       } catch ( final IOException e ) {
-         LOG.error( "Yaml open api specification could not be generated." );
-         throw new InvalidAspectModelException( "Error generating yaml open api specification", e );
+         LOG.error( "YAML OpenAPI specification could not be generated." );
+         throw new InvalidAspectModelException( "Error generating YAML OpenAPI specification", e );
       }
    }
 
@@ -136,8 +136,8 @@ public class GenerateService {
 
          return out.toString();
       } catch ( final IOException e ) {
-         LOG.error( "Json open api specification could not be generated." );
-         throw new InvalidAspectModelException( "Error generating json open api specification", e );
+         LOG.error( "JSON OpenAPI specification could not be generated." );
+         throw new InvalidAspectModelException( "Error generating JSON OpenAPI specification", e );
       }
    }
 }

--- a/src/main/java/io/openmanufacturing/ame/services/GenerateService.java
+++ b/src/main/java/io/openmanufacturing/ame/services/GenerateService.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ImmutableMap;
 
 import io.openmanufacturing.ame.config.ApplicationSettings;
 import io.openmanufacturing.ame.exceptions.InvalidAspectModelException;
-import io.openmanufacturing.ame.resolver.inmemory.InMemoryStrategy;
 import io.openmanufacturing.ame.services.utils.ModelUtils;
 import io.openmanufacturing.sds.aspectmodel.generator.docu.AspectModelDocumentationGenerator;
 import io.openmanufacturing.sds.aspectmodel.generator.json.AspectModelJsonPayloadGenerator;
@@ -114,8 +113,8 @@ public class GenerateService {
       try {
          final AspectModelOpenApiGenerator generator = new AspectModelOpenApiGenerator();
 
-         return generator.applyForYaml( getAspect( aspectModel ), useSemanticVersion, baseUrl, Optional.empty(),
-               Optional.empty(), includeQueryApi, pagingOption );
+         return generator.applyForYaml( ModelUtils.resolveAspectFromModel( aspectModel ), useSemanticVersion, baseUrl,
+               Optional.empty(), Optional.empty(), includeQueryApi, pagingOption );
       } catch ( final IOException e ) {
          LOG.error( "Yaml open api specification could not be generated." );
          throw new InvalidAspectModelException( "Error generating yaml open api specification", e );
@@ -127,8 +126,8 @@ public class GenerateService {
       try {
          final AspectModelOpenApiGenerator generator = new AspectModelOpenApiGenerator();
 
-         final JsonNode json = generator.applyForJson( getAspect( aspectModel ), useSemanticVersion, baseUrl,
-               Optional.empty(), Optional.empty(), includeQueryApi, pagingOption );
+         final JsonNode json = generator.applyForJson( ModelUtils.resolveAspectFromModel( aspectModel ),
+               useSemanticVersion, baseUrl, Optional.empty(), Optional.empty(), includeQueryApi, pagingOption );
 
          final ByteArrayOutputStream out = new ByteArrayOutputStream();
          final ObjectMapper objectMapper = new ObjectMapper();
@@ -140,15 +139,5 @@ public class GenerateService {
          LOG.error( "Json open api specification could not be generated." );
          throw new InvalidAspectModelException( "Error generating json open api specification", e );
       }
-   }
-
-   private Aspect getAspect( final String aspectModel ) {
-      final InMemoryStrategy inMemoryStrategy = ModelUtils.inMemoryStrategy( aspectModel,
-            ApplicationSettings.getMetaModelStoragePath() );
-
-      final VersionedModel versionedModel = ModelUtils.loadAndResolveModel( inMemoryStrategy ).getOrElseThrow(
-            e -> new InvalidAspectModelException( "Cannot create Open API specification.", e ) );
-
-      return AspectModelLoader.fromVersionedModelUnchecked( versionedModel );
    }
 }

--- a/src/main/java/io/openmanufacturing/ame/services/ModelService.java
+++ b/src/main/java/io/openmanufacturing/ame/services/ModelService.java
@@ -114,7 +114,7 @@ public class ModelService {
    }
 
    private Try<VersionedModel> updateModelVersion( final File inputFile ) {
-      return ModelUtils.loadButNotResolveModel( inputFile ).flatMap( new MigratorService()::updateMetaModelVersion );
+      return ModelUtils.loadModelFromFile( inputFile ).flatMap( new MigratorService()::updateMetaModelVersion );
    }
 
    private Namespace resolveNamespace( final List<Namespace> namespaces, final AspectModelUrn aspectModelUrn ) {

--- a/src/main/java/io/openmanufacturing/ame/services/utils/ModelUtils.java
+++ b/src/main/java/io/openmanufacturing/ame/services/utils/ModelUtils.java
@@ -108,7 +108,7 @@ public class ModelUtils {
             new MigratorService()::updateMetaModelVersion );
 
       final VersionedModel versionedModel = migratedFile.getOrElseThrow(
-            e -> new InvalidAspectModelException( "AspectModel cannot be migrated.", e ) );
+            e -> new InvalidAspectModelException( "Aspect Model cannot be migrated.", e ) );
 
       return getPrettyPrintedVersionedModel( versionedModel, inMemoryStrategy.getAspectModelUrn().getUrn() );
    }
@@ -207,8 +207,8 @@ public class ModelUtils {
 
    private static ValidationReport buildValidationSemanticReport( final String message, final String focusNode,
          final String resultPath, final String Severity, final String value ) {
-      return new ValidationReportBuilder().withValidationErrors(
-                                                List.of( new ValidationError.Semantic( message, focusNode, resultPath, Severity, value ) ) )
-                                          .buildInvalidReport();
+      final ValidationError.Semantic semantic = new ValidationError.Semantic( message, focusNode, resultPath, Severity,
+            value );
+      return new ValidationReportBuilder().withValidationErrors( List.of( semantic ) ).buildInvalidReport();
    }
 }

--- a/src/main/java/io/openmanufacturing/ame/web/GenerateResource.java
+++ b/src/main/java/io/openmanufacturing/ame/web/GenerateResource.java
@@ -73,10 +73,10 @@ public class GenerateResource {
    }
 
    /**
-    * This Method is used to generate an open api specification of the aspect model
+    * This method is used to generate an OpenAPI specification of the Aspect Model
     *
     * @param aspectModel the Aspect Model Data
-    * @param output of the open api specification
+    * @param output of the OpenAPI specification
     * @param baseUrl the base URL for the Aspect API
     * @param includeQueryApi if set to true, a path section for the Query API Endpoint of the Aspect API will be
     *       included in the specification
@@ -84,7 +84,7 @@ public class GenerateResource {
     *       the version of the API, otherwise only the major part of the Aspect Version is used as the version of the
     *       API.
     * @param pagingOption if defined, the chosen paging type will be in the JSON.
-    * @return The open api specification
+    * @return The OpenAPI specification
     */
    @PostMapping( "open-api-spec" )
    public ResponseEntity<String> openApiSpec( @RequestBody final String aspectModel,

--- a/src/main/java/io/openmanufacturing/ame/web/GenerateResource.java
+++ b/src/main/java/io/openmanufacturing/ame/web/GenerateResource.java
@@ -20,9 +20,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.openmanufacturing.ame.services.GenerateService;
+import io.openmanufacturing.sds.aspectmodel.generator.openapi.PagingOption;
 
 /**
  * Controller class that supports the generation of the aspect model into other formats.
@@ -45,7 +47,7 @@ public class GenerateResource {
     */
    @PostMapping( "documentation" )
    public ResponseEntity<byte[]> generateHtml( @RequestBody final String aspectModel ) throws IOException {
-      return ResponseEntity.ok( generateService.generateHtmlDocument( aspectModel, Optional.empty() ) );
+      return ResponseEntity.ok( generateService.generateHtmlDocument( aspectModel ) );
    }
 
    /**
@@ -56,7 +58,7 @@ public class GenerateResource {
     */
    @PostMapping( "json-sample" )
    public ResponseEntity<Object> jsonSample( @RequestBody final String aspectModel ) {
-      return ResponseEntity.ok( generateService.sampleJSONPayload( aspectModel, Optional.empty() ) );
+      return ResponseEntity.ok( generateService.sampleJSONPayload( aspectModel ) );
    }
 
    /**
@@ -67,6 +69,30 @@ public class GenerateResource {
     */
    @PostMapping( "json-schema" )
    public ResponseEntity<String> jsonSchema( @RequestBody final String aspectModel ) {
-      return ResponseEntity.ok( generateService.jsonSchema( aspectModel, Optional.empty() ) );
+      return ResponseEntity.ok( generateService.jsonSchema( aspectModel ) );
+   }
+
+   /**
+    * This Method is used to generate an open api specification of the aspect model
+    *
+    * @param aspectModel The Aspect Model Data
+    * @return The open api specification
+    */
+   @PostMapping( "open-api-spec" )
+   public ResponseEntity<String> openApiSpec( @RequestBody final String aspectModel,
+         @RequestParam( name = "json", defaultValue = "false" ) final boolean jsonOutput,
+         @RequestParam( name = "baseUrl", defaultValue = "https://www.example.com" ) final String baseUrl,
+         @RequestParam( name = "includeQueryApi", defaultValue = "false" ) final boolean includeQueryApi,
+         @RequestParam( name = "useSemanticVersion", defaultValue = "false" ) final boolean useSemanticVersion,
+         @RequestParam( name = "pagingOption", defaultValue = "TIME_BASED_PAGING" )
+         final Optional<PagingOption> pagingOption ) {
+
+      final String openApiOutput = jsonOutput ?
+            generateService.generateJsonOpenApiSpec( aspectModel, baseUrl, includeQueryApi, useSemanticVersion,
+                  pagingOption ) :
+            generateService.generateYamlOpenApiSpec( aspectModel, baseUrl, includeQueryApi, useSemanticVersion,
+                  pagingOption );
+
+      return ResponseEntity.ok( openApiOutput );
    }
 }

--- a/src/main/java/io/openmanufacturing/ame/web/GenerateResource.java
+++ b/src/main/java/io/openmanufacturing/ame/web/GenerateResource.java
@@ -42,7 +42,7 @@ public class GenerateResource {
    /**
     * This Method is used to generate a documentation of the aspect model
     *
-    * @param aspectModel - The Aspect Model Data
+    * @param aspectModel the Aspect Model Data
     * @return the aspect model definition as documentation html file.
     */
    @PostMapping( "documentation" )
@@ -53,7 +53,7 @@ public class GenerateResource {
    /**
     * This Method is used to generate a sample JSON Payload of the aspect model
     *
-    * @param aspectModel The Aspect Model Data
+    * @param aspectModel the Aspect Model Data
     * @return The JSON Sample Payload
     */
    @PostMapping( "json-sample" )
@@ -75,19 +75,27 @@ public class GenerateResource {
    /**
     * This Method is used to generate an open api specification of the aspect model
     *
-    * @param aspectModel The Aspect Model Data
+    * @param aspectModel the Aspect Model Data
+    * @param output of the open api specification
+    * @param baseUrl the base URL for the Aspect API
+    * @param includeQueryApi if set to true, a path section for the Query API Endpoint of the Aspect API will be
+    *       included in the specification
+    * @param useSemanticVersion if set to true, the complete semantic version of the Aspect Model will be used as
+    *       the version of the API, otherwise only the major part of the Aspect Version is used as the version of the
+    *       API.
+    * @param pagingOption if defined, the chosen paging type will be in the JSON.
     * @return The open api specification
     */
    @PostMapping( "open-api-spec" )
    public ResponseEntity<String> openApiSpec( @RequestBody final String aspectModel,
-         @RequestParam( name = "json", defaultValue = "false" ) final boolean jsonOutput,
-         @RequestParam( name = "baseUrl", defaultValue = "https://www.example.com" ) final String baseUrl,
+         @RequestParam( name = "output", defaultValue = "yaml" ) final String output,
+         @RequestParam( name = "baseUrl", defaultValue = "https://open-manufacturing.org" ) final String baseUrl,
          @RequestParam( name = "includeQueryApi", defaultValue = "false" ) final boolean includeQueryApi,
          @RequestParam( name = "useSemanticVersion", defaultValue = "false" ) final boolean useSemanticVersion,
          @RequestParam( name = "pagingOption", defaultValue = "TIME_BASED_PAGING" )
          final Optional<PagingOption> pagingOption ) {
 
-      final String openApiOutput = jsonOutput ?
+      final String openApiOutput = output.equals( "json" ) ?
             generateService.generateJsonOpenApiSpec( aspectModel, baseUrl, includeQueryApi, useSemanticVersion,
                   pagingOption ) :
             generateService.generateYamlOpenApiSpec( aspectModel, baseUrl, includeQueryApi, useSemanticVersion,

--- a/src/test/java/io/openmanufacturing/ame/services/GenerateServiceTest.java
+++ b/src/test/java/io/openmanufacturing/ame/services/GenerateServiceTest.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +54,7 @@ public class GenerateServiceTest {
                   .thenReturn( storagePath.toString() );
 
          final String payload = generateService.sampleJSONPayload(
-               Files.readString( storagePath, StandardCharsets.UTF_8 ), Optional.empty() );
+               Files.readString( storagePath, StandardCharsets.UTF_8 ) );
          assertEquals( "{\"property\":\"eOMtThyhVNLWUZNRcBaQKxI\"}", payload );
       }
    }
@@ -70,7 +69,7 @@ public class GenerateServiceTest {
                   .thenReturn( storagePath.toString() );
 
          final String payload = generateService.jsonSchema(
-               Files.readString( storagePath, StandardCharsets.UTF_8 ), Optional.empty() );
+               Files.readString( storagePath, StandardCharsets.UTF_8 ) );
          assertTrue( payload.contains( "#/components/schemas/urn_bamm_io.openmanufacturing_1.0.0_Characteristic" ) );
       }
    }

--- a/src/test/java/io/openmanufacturing/ame/services/GenerateServiceTest.java
+++ b/src/test/java/io/openmanufacturing/ame/services/GenerateServiceTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +31,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.openmanufacturing.ame.repository.strategy.LocalFolderResolverStrategy;
+import io.openmanufacturing.sds.aspectmodel.generator.openapi.PagingOption;
 
 @RunWith( SpringRunner.class )
 @SpringBootTest
@@ -71,6 +73,46 @@ public class GenerateServiceTest {
          final String payload = generateService.jsonSchema(
                Files.readString( storagePath, StandardCharsets.UTF_8 ) );
          assertTrue( payload.contains( "#/components/schemas/urn_bamm_io.openmanufacturing_1.0.0_Characteristic" ) );
+      }
+   }
+
+   @Test
+   public void testAspectModelJsonOpenApiSpec() throws IOException {
+      try ( final MockedStatic<LocalFolderResolverStrategy> utilities = Mockito.mockStatic(
+            LocalFolderResolverStrategy.class ) ) {
+         final Path storagePath = Path.of( openManufacturingTestPath.toString(), aspectModelFile );
+
+         utilities.when( () -> LocalFolderResolverStrategy.transformToValidModelDirectory( any() ) )
+                  .thenReturn( storagePath.toString() );
+
+         final String payload = generateService.generateJsonOpenApiSpec(
+               Files.readString( storagePath, StandardCharsets.UTF_8 ), "https://test.com", false, false,
+               Optional.of( PagingOption.TIME_BASED_PAGING ) );
+
+         assertTrue( payload.contains( "\"openapi\" : \"3.0.3\"" ) );
+         assertTrue( payload.contains( "\"version\" : \"v1\"" ) );
+         assertTrue( payload.contains( "\"title\" : \"AspectModel\"" ) );
+         assertTrue( payload.contains( "\"url\" : \"https://test.com/api/v1\"" ) );
+      }
+   }
+
+   @Test
+   public void testAspectModelYamlOpenApiSpec() throws IOException {
+      try ( final MockedStatic<LocalFolderResolverStrategy> utilities = Mockito.mockStatic(
+            LocalFolderResolverStrategy.class ) ) {
+         final Path storagePath = Path.of( openManufacturingTestPath.toString(), aspectModelFile );
+
+         utilities.when( () -> LocalFolderResolverStrategy.transformToValidModelDirectory( any() ) )
+                  .thenReturn( storagePath.toString() );
+
+         final String payload = generateService.generateYamlOpenApiSpec(
+               Files.readString( storagePath, StandardCharsets.UTF_8 ), "https://test.com", false, false,
+               Optional.of( PagingOption.TIME_BASED_PAGING ) );
+
+         assertTrue( payload.contains( "openapi: 3.0.3" ) );
+         assertTrue( payload.contains( "title: AspectModel" ) );
+         assertTrue( payload.contains( "version: v1" ) );
+         assertTrue( payload.contains( "url: https://test.com/api/v1" ) );
       }
    }
 }


### PR DESCRIPTION
This implementation allows to generate an open api specification. The caller can select whether he prefers Json or Yaml by means of query params.