### PR TITLE
Fix validation of events and abstract entities

### DIFF
--- a/.graalvm/reflect-config.json
+++ b/.graalvm/reflect-config.json
@@ -81,6 +81,28 @@
     ]
   },
   {
+    "name": "io.openmanufacturing.sds.metamodel.loader.instantiator.EventInstantiator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "io.openmanufacturing.sds.metamodel.loader.ModelElementFactory"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.openmanufacturing.sds.metamodel.loader.instantiator.AbstractEntityInstantiator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "io.openmanufacturing.sds.metamodel.loader.ModelElementFactory"
+        ]
+      }
+    ]
+  },
+  {
     "name": "io.openmanufacturing.sds.metamodel.loader.instantiator.EncodingConstraintInstantiator",
     "methods": [
       {


### PR DESCRIPTION
The validation of the elements Event and Abstract Entities could not be carried out because the native image could not execute them correctly. 

The solution is to extend the reflect config so that these are also instantiated.