### PR TITLE
Check Aspect Model if migration is successful

### DIFF
--- a/src/main/java/io/openmanufacturing/ame/services/ModelService.java
+++ b/src/main/java/io/openmanufacturing/ame/services/ModelService.java
@@ -132,12 +132,17 @@ public class ModelService {
    private void namespaceFileInfo( final Namespace namespace, final Try<VersionedModel> model,
          final AspectModelUrn aspectModelUrn, final String storagePath ) {
 
+      boolean modelIsSuccess = false;
+
       if ( model.isSuccess() ) {
          saveVersionedModel( model.get(), aspectModelUrn, storagePath );
+         modelIsSuccess = !getModel(
+               namespace.versionedNamespace + ':' + aspectModelUrn.getName() + ModelUtils.TTL_EXTENSION,
+               Optional.empty() ).contains( "undefined:" );
       }
 
       final AspectModelFile aspectModelFile = new AspectModelFile( aspectModelUrn.getName() + ModelUtils.TTL_EXTENSION,
-            model.isSuccess() );
+            modelIsSuccess );
 
       namespace.addAspectModelFile( aspectModelFile );
    }

--- a/src/main/java/io/openmanufacturing/ame/services/ModelService.java
+++ b/src/main/java/io/openmanufacturing/ame/services/ModelService.java
@@ -138,7 +138,7 @@ public class ModelService {
          saveVersionedModel( model.get(), aspectModelUrn, storagePath );
          modelIsSuccess = !getModel(
                namespace.versionedNamespace + ':' + aspectModelUrn.getName() + ModelUtils.TTL_EXTENSION,
-               Optional.empty() ).contains( "undefined:" );
+               Optional.of( storagePath ) ).contains( "undefined:" );
       }
 
       final AspectModelFile aspectModelFile = new AspectModelFile( aspectModelUrn.getName() + ModelUtils.TTL_EXTENSION,


### PR DESCRIPTION
If shared Aspect Models are defined, they may no longer be available. In this case the editor should receive this information and consider the aspect model as not integrated.